### PR TITLE
hardcoded SOLPS exc and ion rates, switches for SOLKiT CX and diffusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,16 +13,16 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 # Update submodules
 # Adapted from https://cliutils.gitlab.io/modern-cmake/chapters/projects/submodule.html
-find_package(Git QUIET)
-if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
-  message(STATUS "Submodule update")
-  execute_process(COMMAND ${GIT_EXECUTABLE} -c submodule.recurse=false submodule update --init --recursive
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    RESULT_VARIABLE GIT_SUBMOD_RESULT)
-  if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-    message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
-  endif()
-endif()
+#find_package(Git QUIET)
+#if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+#  message(STATUS "Submodule update")
+#  execute_process(COMMAND ${GIT_EXECUTABLE} -c submodule.recurse=false submodule update --init --recursive
+#    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+#    RESULT_VARIABLE GIT_SUBMOD_RESULT)
+#  if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+#    message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+#  endif()
+#endif()
 
 # Get the Git revision
 include(GetGitRevisionDescription)
@@ -34,7 +34,8 @@ message(STATUS "Git revision: ${SD1D_REVISION}")
 
 # BOUT++ is a dependency
 set(BOUT_BUILD_EXAMPLES, OFF) # Don't create example makefiles
-add_subdirectory(external/BOUT-dev)
+#add_subdirectory(external/BOUT-dev)
+find_package(bout++ REQUIRED)
 
 set(SD1D_SOURCES
     sd1d.cxx

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+Modified SD1D
+====
+This is a modified version of SD1D to include:
+- SOLPS AMJUEL ionisation, excitation rates
+- SOLKiT charge exchange and neutral diffusion models
+- New input file option switches for the above
+
+This originally came from SD1D branch hash 2f3da94 on master
+
+
+
+Original SD1D readme is below
+
+
 
 SD1D
 ====

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+cmake . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/ssd_scratch/BOUT-next4may22/BOUT-dev/build
+cd c
+make
+cd ..

--- a/radiation.hxx
+++ b/radiation.hxx
@@ -60,7 +60,9 @@ public:
   BoutReal power(BoutReal Te, BoutReal ne, BoutReal ni);  
 
   // Ionisation rate coefficient <sigma*v> [m3/s]
-  BoutReal ionisation(BoutReal T); 
+  BoutReal ionisation(BoutReal Ne, BoutReal T); 
+  BoutReal ionisation_coronal(BoutReal T);
+  BoutReal ionisation_old(BoutReal T);
   
   // Recombination rate coefficient <sigma*v> [m3/s]
   BoutReal recombination(BoutReal n, BoutReal T);
@@ -68,7 +70,8 @@ public:
   // Charge exchange rate coefficient <sigma*v> [m3/s]
   BoutReal chargeExchange(BoutReal Te);
   
-  BoutReal excitation(BoutReal Te);
+  BoutReal excitation(BoutReal Ne, BoutReal Te);
+  BoutReal excitation_old(BoutReal Te);
 private:
   
 };


### PR DESCRIPTION
This comes from SD8, my previous version of SD1D with hardcoded excitation and ionisation rates coming from AMJUEL H.4 2.1.5. I added SOLKiT CX and neutral diffusion models and enabled them to be turned on/off by setting dn_model and cx_model to "solkit" in the input file