### PR TITLE
Fix

### DIFF
--- a/radiation.cxx
+++ b/radiation.cxx
@@ -365,22 +365,7 @@ BoutReal UpdatedRadiatedPower::chargeExchange(BoutReal T) {
   return 1.0E-6 * exp(lograte);
 }
 
-// <sigma*v> [m3/s]
-// ORIGINAL FUNCTION
-//BoutReal UpdatedRadiatedPower::excitation(BoutReal Te) {
-//  double fEXC;	//<sigma*v> [m3/s]
-//  double TT,Y;
-//  
-//  TT=Te;
-//  
-//  if (TT<1.0) TT=1.0;
-//  Y=10.2/TT;
-//  fEXC=49.0E-14/(0.28+Y)*exp(-Y)*sqrt(Y*(1.0+Y));
-//  
-//  return fEXC;
-//}
-
-// MANUALLY FIT BY MK TO MATCH STEFAN MIJIN THESIS E_iz (SOLKIT)
+// Original excitation rate
 BoutReal UpdatedRadiatedPower::excitation_old(BoutReal Te) {
   double fEXC;	//<sigma*v> [m3/s]
   double TT,Y;
@@ -389,12 +374,13 @@ BoutReal UpdatedRadiatedPower::excitation_old(BoutReal Te) {
   
   if (TT<1.0) TT=1.0;
   Y=10.2/TT;
-  fEXC=1E-13*5.27370587/(1.14166254+Y)*exp(-Y*1.24326264);
+  
+  fEXC=49.0E-14/(0.28+Y)*exp(-Y)*sqrt(Y*(1.0+Y));
   
   return fEXC;
 }
 
-
+// Original ionisation rate
 // Collision rate coefficient <sigma*v> [m3/s]
 BoutReal UpdatedRadiatedPower::ionisation_old(BoutReal T) {
     double fION; // Rate coefficient
@@ -405,8 +391,7 @@ BoutReal UpdatedRadiatedPower::ionisation_old(BoutReal T) {
     }
     
     TT = T;
-	
-// ORIGINAL SD1D RATE
+
     double ioncoeffs[9] = {-3.271397E1, 1.353656E1, -5.739329, 1.563155, \
 			   -2.877056E-1, 3.482560e-2, -2.631976E-3, \
 			   1.119544E-4, -2.039150E-6};

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -557,9 +557,8 @@ protected:
         
         if (cx_model=="solkit") {
           
-          sigma_cx = Nelim(i, j, k) * Nnorm *
-                    (3e-19 * Nnorm * rho_s0) * Vi(i, j, k) * Tnorm /
-                    Omega_ci;
+          sigma_cx = Nelim(i, j, k) * (3e-19 * Nnorm * rho_s0) * Vi(i, j, k) // Dimensionless 
+                    
         } else {
           
           sigma_cx = Nelim(i, j, k) * Nnorm *
@@ -1013,15 +1012,12 @@ protected:
               // SOLKIT MODEL (MK 12/05/2022)
               // CONSTANT CROSS-SECTION 3E-19m2, COLD ION/NEUTRAL AND STATIC NEUTRAL ASSUMPTION
               if (cx_model == "solkit") {
-                R_cx_L = Ne_L * Nn_L *
-                                      3e-19 *Nnorm*rho_s0* Vi_L *
-                                      (Nnorm / Omega_ci);
-                R_cx_C = Ne_C * Nn_C *
-                                      3e-19 *Nnorm*rho_s0* Vi_C *
-                                      (Nnorm / Omega_ci);
-                R_cx_R = Ne_R * Nn_R *
-                                      3e-19 *Nnorm*rho_s0* Vi_R *
-                                      (Nnorm / Omega_ci);
+                R_cx_L = Ne_L * Nn_L * (3e-19 * Nnorm * rho_s0) * Vi_L;
+
+                R_cx_C = Ne_C * Nn_C * (3e-19 * Nnorm * rho_s0) * Vi_C;
+
+                R_cx_R = Ne_R * Nn_R * (3e-19 * Nnorm * rho_s0) * Vi_R;
+
               } else {
               // ORIGINAL MODEL 
                 R_cx_L = Ne_L * Nn_L *

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1227,6 +1227,25 @@ protected:
 
                 Rex(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
                                (6. * J_C);
+                               
+                if (atomic_debug) {							 
+                  // Calculate the old way for comparison
+                  R_ex_L = Ne_L * Nn_L *
+                                    hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
+                                    Omega_ci / Tnorm;
+                  R_ex_C = Ne_C * Nn_C *
+                                    hydrogen.excitation_old(Te_C * Tnorm) * Nnorm /
+                                    Omega_ci / Tnorm;
+                  R_ex_R = Ne_R * Nn_R *
+                                    hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
+                                    Omega_ci / Tnorm;
+                  
+                
+                  Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
+                                 (6. * J_C);
+                }
+              }
+              
               } else {
                 // Calculate the old way for comparison
                 R_ex_L = Ne_L * Nn_L *
@@ -1238,28 +1257,10 @@ protected:
                 R_ex_R = Ne_R * Nn_R *
                                   hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
                                   Omega_ci / Tnorm;
-                
-              
-                Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
-                               (6. * J_C);
+           
               }
                              
-              if (atomic_debug) {							 
-                // Calculate the old way for comparison
-                R_ex_L = Ne_L * Nn_L *
-                                  hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
-                                  Omega_ci / Tnorm;
-                R_ex_C = Ne_C * Nn_C *
-                                  hydrogen.excitation_old(Te_C * Tnorm) * Nnorm /
-                                  Omega_ci / Tnorm;
-                R_ex_R = Ne_R * Nn_R *
-                                  hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
-                                  Omega_ci / Tnorm;
-                
               
-                Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
-                               (6. * J_C);
-              }
             }
 
             // Total energy lost from system

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1102,7 +1102,7 @@ protected:
             if (ionisation) {
               BoutReal R_iz_L, R_iz_C, R_iz_R;
             
-              if (iz_rate=="solps") {
+              if (iz_rate=="solkit") {
                 R_iz_L = Ne_L * Nn_L *
                                   hydrogen.ionisation(Ne_L * Nnorm, Te_L * Tnorm) * Nnorm /
                                   Omega_ci;
@@ -1214,7 +1214,7 @@ protected:
               // for in the excitation energy rate already. Note functions are in m-3 hence 1e8 * 1e6
               BoutReal R_ex_L, R_ex_C, R_ex_R;
 
-              if (ex_rate=="solps") {
+              if (ex_rate=="solkit") {
                 R_ex_L = Ne_L * Nn_L *
                                   (hydrogen.excitation(Ne_L * Nnorm, Te_L * Tnorm) - hydrogen.ionisation(1e8*1e6, Te_L * Tnorm) * 13.6) * Nnorm /
                                   Omega_ci / Tnorm;

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1011,15 +1011,12 @@ protected:
         
               // SOLKIT MODEL (MK 12/05/2022)
               // CONSTANT CROSS-SECTION 3E-19m2, COLD ION/NEUTRAL AND STATIC NEUTRAL ASSUMPTION
-              
-              // Multiplied by Omega_Ci only because it's what it takes to get the results right......
-              // As far as I know this is not correct.
               if (cx_model == "solkit") {
-                R_cx_L = Ne_L * Nn_L * (3e-19 * Nnorm * rho_s0) * Vi_L * Omega_ci;
+                R_cx_L = Ne_L * Nn_L * (3e-19 * Nnorm * rho_s0) * Vi_L;
 
-                R_cx_C = Ne_C * Nn_C * (3e-19 * Nnorm * rho_s0) * Vi_C * Omega_ci;
+                R_cx_C = Ne_C * Nn_C * (3e-19 * Nnorm * rho_s0) * Vi_C;
 
-                R_cx_R = Ne_R * Nn_R * (3e-19 * Nnorm * rho_s0) * Vi_R * Omega_ci;
+                R_cx_R = Ne_R * Nn_R * (3e-19 * Nnorm * rho_s0) * Vi_R;
 
               } else {
               // ORIGINAL MODEL 

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -149,8 +149,8 @@ protected:
             .withDefault<bool>(true);
             
     // MK ADDITIONS
-    OPTION(opt, iz_rate, "default"); // Set to "SOLPS" to enable rate H.4 2.1.5 used in SOLPS and in SOLKiT 
-    OPTION(opt, ex_rate, "default"); // Set to "SOLPS" to enable rate H.10 2.1.5 used in SOLPS and in SOLKiT 
+    OPTION(opt, iz_rate, "default"); // Set to "solkit" to enable rate H.4 2.1.5 used in SOLPS and in SOLKiT 
+    OPTION(opt, ex_rate, "default"); // Set to "solkit" to enable rate H.10 2.1.5 used in SOLPS and in SOLKiT 
     OPTION(opt, dn_model, "default"); // Set to "solkit" to enable SOLKiT neutral diffusion
     OPTION(opt, cx_model, "default"); // Set to "solkit" to enable SOLKiT charge exchange friction
     OPTION(opt, atomic_debug, false); // Save Siz_compare and Rex_compare which correspond to SD1D default Siz & Rex 

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -557,7 +557,7 @@ protected:
         
         if (cx_model=="solkit") {
           
-          sigma_cx = Nelim(i, j, k) * (3e-19 * Nnorm * rho_s0) * Vi(i, j, k); // Dimensionless 
+          sigma_cx = Nelim(i, j, k) * (3e-19 * Nnorm * rho_s0) * Vi(i, j, k) // Dimensionless 
                     
         } else {
           

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -557,7 +557,7 @@ protected:
         
         if (cx_model=="solkit") {
           
-          sigma_cx = Nelim(i, j, k) * (3e-19 * Nnorm * rho_s0) * Vi(i, j, k) // Dimensionless 
+          sigma_cx = Nelim(i, j, k) * (3e-19 * Nnorm * rho_s0) * Vi(i, j, k); // Dimensionless 
                     
         } else {
           

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1151,14 +1151,14 @@ protected:
                 // Rate diagnostics
                 // Calculate field Siz_compare which is saved but doesn't go into other calculations
                 R_iz_L = Ne_L * Nn_L *
-                hydrogen.ionisation(Ne_L * Nnorm, Te_L * Tnorm) * Nnorm /
-                Omega_ci;
+                                hydrogen.ionisation_old(Te_L * Tnorm) * Nnorm /
+                                Omega_ci;
                 R_iz_C = Ne_C * Nn_C *
-                hydrogen.ionisation(Ne_C * Nnorm, Te_C * Tnorm) * Nnorm /
-                Omega_ci;
+                                  hydrogen.ionisation_old(Te_C * Tnorm) * Nnorm /
+                                  Omega_ci;
                 R_iz_R = Ne_R * Nn_R *
-                hydrogen.ionisation(Ne_R * Nnorm, Te_R * Tnorm) * Nnorm /
-                Omega_ci;
+                                  hydrogen.ionisation_old(Te_R * Tnorm) * Nnorm /
+                                  Omega_ci;
 
                 Siz_compare(i, j, k) =
                 -(J_L * R_iz_L + 4. * J_C * R_iz_C + J_R * R_iz_R) /
@@ -1255,6 +1255,9 @@ protected:
                 R_ex_R = Ne_R * Nn_R *
                                   hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
                                   Omega_ci / Tnorm;
+                                  
+                Rex(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
+                               (6. * J_C);
               }
             }
 

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -599,6 +599,8 @@ protected:
           
                 if (dn_model=="solkit") {
                   
+                  BoutReal sigma_ne = 
+                  
                   Dn(i, j, k) = dneut(i, j, k) * sqrt(3 / Tnorm) / (2 * ((8.8e-21*Nnorm*rho_s0) * (Nelim(i, j, k) + Nnlim(i, j, k)) + (3e-19*Nnorm*rho_s0) * Nelim(i, j, k)));
                 } else {
                   Dn(i, j, k) = dneut(i, j, k) * SQ(vth_n) / sigma;
@@ -1012,13 +1014,13 @@ protected:
               // CONSTANT CROSS-SECTION 3E-19m2, COLD ION/NEUTRAL AND STATIC NEUTRAL ASSUMPTION
               if (cx_model == "solkit") {
                 R_cx_L = Ne_L * Nn_L *
-                                      3e-19 * Vi_L *
+                                      3e-19 *Nnorm*rho_s0* Vi_L *
                                       (Nnorm / Omega_ci);
                 R_cx_C = Ne_C * Nn_C *
-                                      3e-19 * Vi_C *
+                                      3e-19 *Nnorm*rho_s0* Vi_C *
                                       (Nnorm / Omega_ci);
                 R_cx_R = Ne_R * Nn_R *
-                                      3e-19 * Vi_R *
+                                      3e-19 *Nnorm*rho_s0* Vi_R *
                                       (Nnorm / Omega_ci);
               } else {
               // ORIGINAL MODEL 

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1244,10 +1244,8 @@ protected:
                   Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
                                  (6. * J_C);
                 }
-              }
-              
               } else {
-                // Calculate the old way for comparison
+                // Calculate the SD1D default way
                 R_ex_L = Ne_L * Nn_L *
                                   hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
                                   Omega_ci / Tnorm;
@@ -1257,10 +1255,7 @@ protected:
                 R_ex_R = Ne_R * Nn_R *
                                   hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
                                   Omega_ci / Tnorm;
-           
               }
-                             
-              
             }
 
             // Total energy lost from system

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1011,12 +1011,15 @@ protected:
         
               // SOLKIT MODEL (MK 12/05/2022)
               // CONSTANT CROSS-SECTION 3E-19m2, COLD ION/NEUTRAL AND STATIC NEUTRAL ASSUMPTION
+              
+              // Multiplied by Omega_Ci only because it's what it takes to get the results right......
+              // As far as I know this is not correct.
               if (cx_model == "solkit") {
-                R_cx_L = Ne_L * Nn_L * (3e-19 * Nnorm * rho_s0) * Vi_L;
+                R_cx_L = Ne_L * Nn_L * (3e-19 * Nnorm * rho_s0) * Vi_L * Omega_ci;
 
-                R_cx_C = Ne_C * Nn_C * (3e-19 * Nnorm * rho_s0) * Vi_C;
+                R_cx_C = Ne_C * Nn_C * (3e-19 * Nnorm * rho_s0) * Vi_C * Omega_ci;
 
-                R_cx_R = Ne_R * Nn_R * (3e-19 * Nnorm * rho_s0) * Vi_R;
+                R_cx_R = Ne_R * Nn_R * (3e-19 * Nnorm * rho_s0) * Vi_R * Omega_ci;
 
               } else {
               // ORIGINAL MODEL 


### PR DESCRIPTION
This branch goes over the implementation of SOLPS/SOLKiT ionisation and excitation rates, as well as the SOLKiT charge exchange  and neutral diffusion model. Previously these implementations were not verified against synthesised results in Python. Doing so uncovered lots of issues, a lot of which were due to improper normalisation.

This was done in study Rexfix and the final "fix" case was prefix fc7, for fix - prefix c (CX/IZ/Dn/EX all implemented) - fix 7.

Here is the CX/Dn verification:
![image](https://user-images.githubusercontent.com/62797494/169659133-5423e094-49fb-4f44-9d19-9b41532b178f.png)

Net excitation:
![image](https://user-images.githubusercontent.com/62797494/169659158-3c8a00e7-1673-4e0d-acbc-7e6686d0fb9f.png)

Ionisation:
![image](https://user-images.githubusercontent.com/62797494/169659175-d50cf0ca-e919-4d9b-8935-f3fd60e6b1fc.png)
