### PR TITLE
Next

### DIFF
--- a/radiation.cxx
+++ b/radiation.cxx
@@ -365,22 +365,7 @@ BoutReal UpdatedRadiatedPower::chargeExchange(BoutReal T) {
   return 1.0E-6 * exp(lograte);
 }
 
-// <sigma*v> [m3/s]
-// ORIGINAL FUNCTION
-//BoutReal UpdatedRadiatedPower::excitation(BoutReal Te) {
-//  double fEXC;	//<sigma*v> [m3/s]
-//  double TT,Y;
-//  
-//  TT=Te;
-//  
-//  if (TT<1.0) TT=1.0;
-//  Y=10.2/TT;
-//  fEXC=49.0E-14/(0.28+Y)*exp(-Y)*sqrt(Y*(1.0+Y));
-//  
-//  return fEXC;
-//}
-
-// MANUALLY FIT BY MK TO MATCH STEFAN MIJIN THESIS E_iz (SOLKIT)
+// Original excitation rate
 BoutReal UpdatedRadiatedPower::excitation_old(BoutReal Te) {
   double fEXC;	//<sigma*v> [m3/s]
   double TT,Y;
@@ -389,12 +374,13 @@ BoutReal UpdatedRadiatedPower::excitation_old(BoutReal Te) {
   
   if (TT<1.0) TT=1.0;
   Y=10.2/TT;
-  fEXC=1E-13*5.27370587/(1.14166254+Y)*exp(-Y*1.24326264);
+  
+  fEXC=49.0E-14/(0.28+Y)*exp(-Y)*sqrt(Y*(1.0+Y));
   
   return fEXC;
 }
 
-
+// Original ionisation rate
 // Collision rate coefficient <sigma*v> [m3/s]
 BoutReal UpdatedRadiatedPower::ionisation_old(BoutReal T) {
     double fION; // Rate coefficient
@@ -405,8 +391,7 @@ BoutReal UpdatedRadiatedPower::ionisation_old(BoutReal T) {
     }
     
     TT = T;
-	
-// ORIGINAL SD1D RATE
+
     double ioncoeffs[9] = {-3.271397E1, 1.353656E1, -5.739329, 1.563155, \
 			   -2.877056E-1, 3.482560e-2, -2.631976E-3, \
 			   1.119544E-4, -2.039150E-6};

--- a/radiation.cxx
+++ b/radiation.cxx
@@ -528,33 +528,6 @@ BoutReal UpdatedRadiatedPower::ionisation(BoutReal n, BoutReal T) {
   return fION;
 }
 
-// Collision rate coefficient <sigma*v> [m3/s]
-// COMES FROM AMJUEL H.4 2.1.5 (SAWADA) E-index 0 (no density dependence, i.e. coronal approximation)
-BoutReal UpdatedRadiatedPower::ionisation_coronal(BoutReal T) {
-    double fION; // Rate coefficient
-    double TT;
-
-    if (T < 0.025) {
-      T = 0.025; // 300K
-    }
-    
-    TT = T;
-	
-    double ioncoeffs[9] = {-3.248025330340E+01, 1.425332391510E+01, -6.632235026785E+00, \
-			   1.425332391510E+01, -6.632235026785E+00, 2.059544135448E+00, \
-			   -6.632235026785E+00, 2.059544135448E+00, -4.425370331410E-01};
-    
-    double lograte = 0.0;
-    for (int i=0;i<=8;i++)
-      {
-	lograte = lograte + ioncoeffs[i]*pow(log(TT),i);
-      }
-
-    fION = exp(lograte)*1.0E-6;
-
-    return fION;
-}
-
 // COMES FROM AMJUEL H.10 2.1.5 (SAWADA)
 // This is an energy weighted rate (m-3s-1eV) for energy loss due to multistep ionisation in a 9 coefficient 2D polynomial fit
 // It includes energy loss due to ionisation (i.e. 13.6eV) within it, so for SD1D's definition we need to separate this out later

--- a/radiation.hxx
+++ b/radiation.hxx
@@ -61,7 +61,6 @@ public:
 
   // Ionisation rate coefficient <sigma*v> [m3/s]
   BoutReal ionisation(BoutReal Ne, BoutReal T); 
-  BoutReal ionisation_coronal(BoutReal T);
   BoutReal ionisation_old(BoutReal T);
   
   // Recombination rate coefficient <sigma*v> [m3/s]

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -557,9 +557,8 @@ protected:
         
         if (cx_model=="solkit") {
           
-          sigma_cx = Nelim(i, j, k) * Nnorm *
-                    (3e-19 * Nnorm * rho_s0) * Vi(i, j, k) * Tnorm /
-                    Omega_ci;
+          sigma_cx = Nelim(i, j, k) * (3e-19 * Nnorm * rho_s0) * Vi(i, j, k) // Dimensionless 
+                    
         } else {
           
           sigma_cx = Nelim(i, j, k) * Nnorm *
@@ -1013,15 +1012,12 @@ protected:
               // SOLKIT MODEL (MK 12/05/2022)
               // CONSTANT CROSS-SECTION 3E-19m2, COLD ION/NEUTRAL AND STATIC NEUTRAL ASSUMPTION
               if (cx_model == "solkit") {
-                R_cx_L = Ne_L * Nn_L *
-                                      3e-19 *Nnorm*rho_s0* Vi_L *
-                                      (Nnorm / Omega_ci);
-                R_cx_C = Ne_C * Nn_C *
-                                      3e-19 *Nnorm*rho_s0* Vi_C *
-                                      (Nnorm / Omega_ci);
-                R_cx_R = Ne_R * Nn_R *
-                                      3e-19 *Nnorm*rho_s0* Vi_R *
-                                      (Nnorm / Omega_ci);
+                R_cx_L = Ne_L * Nn_L * (3e-19 * Nnorm * rho_s0) * Vi_L;
+
+                R_cx_C = Ne_C * Nn_C * (3e-19 * Nnorm * rho_s0) * Vi_C;
+
+                R_cx_R = Ne_R * Nn_R * (3e-19 * Nnorm * rho_s0) * Vi_R;
+
               } else {
               // ORIGINAL MODEL 
                 R_cx_L = Ne_L * Nn_L *

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1227,6 +1227,25 @@ protected:
 
                 Rex(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
                                (6. * J_C);
+                               
+                if (atomic_debug) {							 
+                  // Calculate the old way for comparison
+                  R_ex_L = Ne_L * Nn_L *
+                                    hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
+                                    Omega_ci / Tnorm;
+                  R_ex_C = Ne_C * Nn_C *
+                                    hydrogen.excitation_old(Te_C * Tnorm) * Nnorm /
+                                    Omega_ci / Tnorm;
+                  R_ex_R = Ne_R * Nn_R *
+                                    hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
+                                    Omega_ci / Tnorm;
+                  
+                
+                  Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
+                                 (6. * J_C);
+                }
+              }
+              
               } else {
                 // Calculate the old way for comparison
                 R_ex_L = Ne_L * Nn_L *
@@ -1238,28 +1257,10 @@ protected:
                 R_ex_R = Ne_R * Nn_R *
                                   hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
                                   Omega_ci / Tnorm;
-                
-              
-                Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
-                               (6. * J_C);
+           
               }
                              
-              if (atomic_debug) {							 
-                // Calculate the old way for comparison
-                R_ex_L = Ne_L * Nn_L *
-                                  hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
-                                  Omega_ci / Tnorm;
-                R_ex_C = Ne_C * Nn_C *
-                                  hydrogen.excitation_old(Te_C * Tnorm) * Nnorm /
-                                  Omega_ci / Tnorm;
-                R_ex_R = Ne_R * Nn_R *
-                                  hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
-                                  Omega_ci / Tnorm;
-                
               
-                Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
-                               (6. * J_C);
-              }
             }
 
             // Total energy lost from system

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1102,7 +1102,7 @@ protected:
             if (ionisation) {
               BoutReal R_iz_L, R_iz_C, R_iz_R;
             
-              if (iz_rate=="solps") {
+              if (iz_rate=="solkit") {
                 R_iz_L = Ne_L * Nn_L *
                                   hydrogen.ionisation(Ne_L * Nnorm, Te_L * Tnorm) * Nnorm /
                                   Omega_ci;
@@ -1214,7 +1214,7 @@ protected:
               // for in the excitation energy rate already. Note functions are in m-3 hence 1e8 * 1e6
               BoutReal R_ex_L, R_ex_C, R_ex_R;
 
-              if (ex_rate=="solps") {
+              if (ex_rate=="solkit") {
                 R_ex_L = Ne_L * Nn_L *
                                   (hydrogen.excitation(Ne_L * Nnorm, Te_L * Tnorm) - hydrogen.ionisation(1e8*1e6, Te_L * Tnorm) * 13.6) * Nnorm /
                                   Omega_ci / Tnorm;

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1011,15 +1011,12 @@ protected:
         
               // SOLKIT MODEL (MK 12/05/2022)
               // CONSTANT CROSS-SECTION 3E-19m2, COLD ION/NEUTRAL AND STATIC NEUTRAL ASSUMPTION
-              
-              // Multiplied by Omega_Ci only because it's what it takes to get the results right......
-              // As far as I know this is not correct.
               if (cx_model == "solkit") {
-                R_cx_L = Ne_L * Nn_L * (3e-19 * Nnorm * rho_s0) * Vi_L * Omega_ci;
+                R_cx_L = Ne_L * Nn_L * (3e-19 * Nnorm * rho_s0) * Vi_L;
 
-                R_cx_C = Ne_C * Nn_C * (3e-19 * Nnorm * rho_s0) * Vi_C * Omega_ci;
+                R_cx_C = Ne_C * Nn_C * (3e-19 * Nnorm * rho_s0) * Vi_C;
 
-                R_cx_R = Ne_R * Nn_R * (3e-19 * Nnorm * rho_s0) * Vi_R * Omega_ci;
+                R_cx_R = Ne_R * Nn_R * (3e-19 * Nnorm * rho_s0) * Vi_R;
 
               } else {
               // ORIGINAL MODEL 

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -149,8 +149,8 @@ protected:
             .withDefault<bool>(true);
             
     // MK ADDITIONS
-    OPTION(opt, iz_rate, "default"); // Set to "SOLPS" to enable rate H.4 2.1.5 used in SOLPS and in SOLKiT 
-    OPTION(opt, ex_rate, "default"); // Set to "SOLPS" to enable rate H.10 2.1.5 used in SOLPS and in SOLKiT 
+    OPTION(opt, iz_rate, "default"); // Set to "solkit" to enable rate H.4 2.1.5 used in SOLPS and in SOLKiT 
+    OPTION(opt, ex_rate, "default"); // Set to "solkit" to enable rate H.10 2.1.5 used in SOLPS and in SOLKiT 
     OPTION(opt, dn_model, "default"); // Set to "solkit" to enable SOLKiT neutral diffusion
     OPTION(opt, cx_model, "default"); // Set to "solkit" to enable SOLKiT charge exchange friction
     OPTION(opt, atomic_debug, false); // Save Siz_compare and Rex_compare which correspond to SD1D default Siz & Rex 

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -147,13 +147,13 @@ protected:
         opt["bndry_flux_fix"]
             .doc("Calculate boundary fluxes using simple mid-point (recommended)")
             .withDefault<bool>(true);
-						
-		// MK ADDITIONS
-		OPTION(opt, iz_rate, "default"); // Set to "SOLPS" to enable rate H.4 2.1.5 used in SOLPS and in SOLKiT 
-		OPTION(opt, ex_rate, "default"); // Set to "SOLPS" to enable rate H.10 2.1.5 used in SOLPS and in SOLKiT 
-		OPTION(opt, dn_model, "default"); // Set to "solkit" to enable SOLKiT neutral diffusion
-		OPTION(opt, cx_model, "default"); // Set to "solkit" to enable SOLKiT charge exchange friction
-		OPTION(opt, atomic_debug, false); // Save Siz_compare and Rex_compare which correspond to SD1D default Siz & Rex 
+            
+    // MK ADDITIONS
+    OPTION(opt, iz_rate, "default"); // Set to "SOLPS" to enable rate H.4 2.1.5 used in SOLPS and in SOLKiT 
+    OPTION(opt, ex_rate, "default"); // Set to "SOLPS" to enable rate H.10 2.1.5 used in SOLPS and in SOLKiT 
+    OPTION(opt, dn_model, "default"); // Set to "solkit" to enable SOLKiT neutral diffusion
+    OPTION(opt, cx_model, "default"); // Set to "solkit" to enable SOLKiT charge exchange friction
+    OPTION(opt, atomic_debug, false); // Save Siz_compare and Rex_compare which correspond to SD1D default Siz & Rex 
 
     // Field factory for generating fields from strings
     FieldFactory ffact(mesh);
@@ -305,7 +305,7 @@ protected:
                                  // power, energy transfer, friction
       SAVE_REPEAT2(Dn, kappa_n); // Neutral diffusion coefficients
       if (mesh->lastY()){        // only dump where we set the value
-				SAVE_REPEAT(flux_ion);   // Flux of ions to target
+        SAVE_REPEAT(flux_ion);   // Flux of ions to target
       }
     }
     if (heat_conduction) {
@@ -341,9 +341,9 @@ protected:
         }
 
         /// Rate diagnostics
-		if (atomic_debug) {
+    if (atomic_debug) {
         SAVE_REPEAT2(Siz_compare, Rex_compare);
-		}
+    }
       }
 
       SAVE_REPEAT(Vi);
@@ -550,22 +550,22 @@ protected:
             for (int k = 0; k < mesh->LocalNz; k++) {
               // Charge exchange frequency, normalised to ion cyclotron
               // frequency
-			  
-			  // Initialise outside of the if statement
-			  // Cross-sections normalised as sigma*Nnorm*rho_s0 == [m2][m-3][m]
-			  BoutReal sigma_cx;
-			  
-			  if (cx_model=="solkit") {
-				  
-				  sigma_cx = Nelim(i, j, k) * Nnorm *
-									  (3e-19 * Nnorm * rho_s0) * Vi(i, j, k) * Tnorm /
-									  Omega_ci;
-			  } else {
-				  
-				  sigma_cx = Nelim(i, j, k) * Nnorm *
-									  hydrogen.chargeExchange(Te(i, j, k) * Tnorm) /
-									  Omega_ci;
-			  }
+        
+        // Initialise outside of the if statement
+        // Cross-sections normalised as sigma*Nnorm*rho_s0 == [m2][m-3][m]
+        BoutReal sigma_cx;
+        
+        if (cx_model=="solkit") {
+          
+          sigma_cx = Nelim(i, j, k) * Nnorm *
+                    (3e-19 * Nnorm * rho_s0) * Vi(i, j, k) * Tnorm /
+                    Omega_ci;
+        } else {
+          
+          sigma_cx = Nelim(i, j, k) * Nnorm *
+                    hydrogen.chargeExchange(Te(i, j, k) * Tnorm) /
+                    Omega_ci;
+        }
 
               // Ionisation frequency
               BoutReal sigma_iz = Nelim(i, j, k) * Nnorm *
@@ -596,15 +596,15 @@ protected:
 
               // Neutral gas diffusion
               if (include_dneut) {
-				  
-								if (dn_model=="solkit") {
-									
-									Dn(i, j, k) = dneut(i, j, k) * sqrt(3 / Tnorm) / (2 * ((8.8e-21*Nnorm*rho_s0) * (Nelim(i, j, k) + Nnlim(i, j, k)) + (3e-19*Nnorm*rho_s0) * Nelim(i, j, k)));
-								} else {
-									Dn(i, j, k) = dneut(i, j, k) * SQ(vth_n) / sigma;
-								}
-												// Neutral gas heat conduction
-												kappa_n(i, j, k) = dneut(i, j, k) * Nnlim(i, j, k) * SQ(vth_n) / sigma;
+          
+                if (dn_model=="solkit") {
+                  
+                  Dn(i, j, k) = dneut(i, j, k) * sqrt(3 / Tnorm) / (2 * ((8.8e-21*Nnorm*rho_s0) * (Nelim(i, j, k) + Nnlim(i, j, k)) + (3e-19*Nnorm*rho_s0) * Nelim(i, j, k)));
+                } else {
+                  Dn(i, j, k) = dneut(i, j, k) * SQ(vth_n) / sigma;
+                }
+                        // Neutral gas heat conduction
+                        kappa_n(i, j, k) = dneut(i, j, k) * Nnlim(i, j, k) * SQ(vth_n) / sigma;
               }
             }
 
@@ -1002,37 +1002,37 @@ protected:
 
             ///////////////////////////////////////
             // Charge exchange
-			
-			// These need initialisation outside of the if statements
-			BoutReal R_cx_L, R_cx_C, R_cx_R;
-			
+      
+      // These need initialisation outside of the if statements
+      BoutReal R_cx_L, R_cx_C, R_cx_R;
+      
             if (charge_exchange) {
-				
-							// SOLKIT MODEL (MK 12/05/2022)
-							// CONSTANT CROSS-SECTION 3E-19m2, COLD ION/NEUTRAL AND STATIC NEUTRAL ASSUMPTION
-							if (cx_model == "solkit") {
-								R_cx_L = Ne_L * Nn_L *
-																			3e-19 * Vi_L *
-																			(Nnorm / Omega_ci);
-								R_cx_C = Ne_C * Nn_C *
-																			3e-19 * Vi_C *
-																			(Nnorm / Omega_ci);
-								R_cx_R = Ne_R * Nn_R *
-																			3e-19 * Vi_R *
-																			(Nnorm / Omega_ci);
-							} else {
-							// ORIGINAL MODEL 
-								R_cx_L = Ne_L * Nn_L *
-												hydrogen.chargeExchange(Te_L * Tnorm) *
-												(Nnorm / Omega_ci);
-								R_cx_C = Ne_C * Nn_C *
-												hydrogen.chargeExchange(Te_C * Tnorm) *
-												(Nnorm / Omega_ci);
-								R_cx_R = Ne_R * Nn_R *
-												hydrogen.chargeExchange(Te_R * Tnorm) *
-												(Nnorm / Omega_ci);
-							}
-			
+        
+              // SOLKIT MODEL (MK 12/05/2022)
+              // CONSTANT CROSS-SECTION 3E-19m2, COLD ION/NEUTRAL AND STATIC NEUTRAL ASSUMPTION
+              if (cx_model == "solkit") {
+                R_cx_L = Ne_L * Nn_L *
+                                      3e-19 * Vi_L *
+                                      (Nnorm / Omega_ci);
+                R_cx_C = Ne_C * Nn_C *
+                                      3e-19 * Vi_C *
+                                      (Nnorm / Omega_ci);
+                R_cx_R = Ne_R * Nn_R *
+                                      3e-19 * Vi_R *
+                                      (Nnorm / Omega_ci);
+              } else {
+              // ORIGINAL MODEL 
+                R_cx_L = Ne_L * Nn_L *
+                        hydrogen.chargeExchange(Te_L * Tnorm) *
+                        (Nnorm / Omega_ci);
+                R_cx_C = Ne_C * Nn_C *
+                        hydrogen.chargeExchange(Te_C * Tnorm) *
+                        (Nnorm / Omega_ci);
+                R_cx_R = Ne_R * Nn_R *
+                        hydrogen.chargeExchange(Te_R * Tnorm) *
+                        (Nnorm / Omega_ci);
+              }
+      
               // Ecx is energy transferred to neutrals
               Ecx(i, j, k) = (3. / 2) *
                              (J_L * (Te_L - Tn_L) * R_cx_L +
@@ -1100,36 +1100,36 @@ protected:
             // Ionisation
 
             if (ionisation) {
-							BoutReal R_iz_L, R_iz_C, R_iz_R;
-						
-							if (iz_rate=="solps") {
-								R_iz_L = Ne_L * Nn_L *
-																	hydrogen.ionisation(Ne_L * Nnorm, Te_L * Tnorm) * Nnorm /
-																	Omega_ci;
-								R_iz_C = Ne_C * Nn_C *
-																	hydrogen.ionisation(Ne_C * Nnorm, Te_C * Tnorm) * Nnorm /
-																	Omega_ci;
-								R_iz_R = Ne_R * Nn_R *
-																	hydrogen.ionisation(Ne_R * Nnorm, Te_R * Tnorm) * Nnorm /
-																	Omega_ci;
-							} else {
-								R_iz_L = Ne_L * Nn_L *
+              BoutReal R_iz_L, R_iz_C, R_iz_R;
+            
+              if (iz_rate=="solps") {
+                R_iz_L = Ne_L * Nn_L *
+                                  hydrogen.ionisation(Ne_L * Nnorm, Te_L * Tnorm) * Nnorm /
+                                  Omega_ci;
+                R_iz_C = Ne_C * Nn_C *
+                                  hydrogen.ionisation(Ne_C * Nnorm, Te_C * Tnorm) * Nnorm /
+                                  Omega_ci;
+                R_iz_R = Ne_R * Nn_R *
+                                  hydrogen.ionisation(Ne_R * Nnorm, Te_R * Tnorm) * Nnorm /
+                                  Omega_ci;
+              } else {
+                R_iz_L = Ne_L * Nn_L *
                                 hydrogen.ionisation_old(Te_L * Tnorm) * Nnorm /
                                 Omega_ci;
-								R_iz_C = Ne_C * Nn_C *
-																	hydrogen.ionisation_old(Te_C * Tnorm) * Nnorm /
-																	Omega_ci;
-								R_iz_R = Ne_R * Nn_R *
-																	hydrogen.ionisation_old(Te_R * Tnorm) * Nnorm /
-																	Omega_ci;
-							}
+                R_iz_C = Ne_C * Nn_C *
+                                  hydrogen.ionisation_old(Te_C * Tnorm) * Nnorm /
+                                  Omega_ci;
+                R_iz_R = Ne_R * Nn_R *
+                                  hydrogen.ionisation_old(Te_R * Tnorm) * Nnorm /
+                                  Omega_ci;
+              }
 
               Riz(i, j, k) =
                   (Eionize / Tnorm) *
                   ( // Energy loss per ionisation
                       J_L * R_iz_L + 4. * J_C * R_iz_C + J_R * R_iz_R) /
                   (6. * J_C);
-									
+                  
               Eiz(i, j, k) =
                   -(3. / 2) *
                   ( // Energy from neutral atom temperature
@@ -1146,25 +1146,25 @@ protected:
               Siz(i, j, k) =
                   -(J_L * R_iz_L + 4. * J_C * R_iz_C + J_R * R_iz_R) /
                   (6. * J_C);
-			  
-							if (atomic_debug) {
-								// Rate diagnostics
-								// Calculate field Siz_compare which is saved but doesn't go into other calculations
-								R_iz_L = Ne_L * Nn_L *
-								hydrogen.ionisation(Ne_L * Nnorm, Te_L * Tnorm) * Nnorm /
-								Omega_ci;
-								R_iz_C = Ne_C * Nn_C *
-								hydrogen.ionisation(Ne_C * Nnorm, Te_C * Tnorm) * Nnorm /
-								Omega_ci;
-								R_iz_R = Ne_R * Nn_R *
-								hydrogen.ionisation(Ne_R * Nnorm, Te_R * Tnorm) * Nnorm /
-								Omega_ci;
+        
+              if (atomic_debug) {
+                // Rate diagnostics
+                // Calculate field Siz_compare which is saved but doesn't go into other calculations
+                R_iz_L = Ne_L * Nn_L *
+                hydrogen.ionisation(Ne_L * Nnorm, Te_L * Tnorm) * Nnorm /
+                Omega_ci;
+                R_iz_C = Ne_C * Nn_C *
+                hydrogen.ionisation(Ne_C * Nnorm, Te_C * Tnorm) * Nnorm /
+                Omega_ci;
+                R_iz_R = Ne_R * Nn_R *
+                hydrogen.ionisation(Ne_R * Nnorm, Te_R * Tnorm) * Nnorm /
+                Omega_ci;
 
-								Siz_compare(i, j, k) =
-								-(J_L * R_iz_L + 4. * J_C * R_iz_C + J_R * R_iz_R) /
-								(6. * J_C);
-							}
-						}
+                Siz_compare(i, j, k) =
+                -(J_L * R_iz_L + 4. * J_C * R_iz_C + J_R * R_iz_R) /
+                (6. * J_C);
+              }
+            }
 
             if (elastic_scattering) {
               /////////////////////////////////////////////////////////
@@ -1209,54 +1209,54 @@ protected:
               // Currently assuming that quantity calculated is in [eV m^3/s]
               // MK modified this to calculate net excitation rate from AMJUEL 
               // effective excitation energy rate minus base ionisation energy cost 13.6eV * fION  
-							BoutReal R_ex_L, R_ex_C, R_ex_R;
-							
-							if (ex_rate=="solps") {
-								R_ex_L = Ne_L * Nn_L *
-																	(hydrogen.excitation(Ne_L * Nnorm, Te_L * Tnorm) - hydrogen.ionisation_coronal(Te_L * Tnorm) * 13.6) * Nnorm /
-																	Omega_ci / Tnorm;
-								R_ex_C = Ne_C * Nn_C *
-																	(hydrogen.excitation(Ne_C * Nnorm, Te_C * Tnorm) - hydrogen.ionisation_coronal(Te_C * Tnorm) * 13.6) * Nnorm /
-																	Omega_ci / Tnorm;
-								R_ex_R = Ne_R * Nn_R *
-																	(hydrogen.excitation(Ne_R * Nnorm, Te_R * Tnorm) - hydrogen.ionisation_coronal(Te_R * Tnorm) * 13.6) * Nnorm /
-																	Omega_ci / Tnorm;
-									
-								Rex(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
-															 (6. * J_C);
-							} else {
-								// Calculate the old way for comparison
-								R_ex_L = Ne_L * Nn_L *
-																	hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
-																	Omega_ci / Tnorm;
-								R_ex_C = Ne_C * Nn_C *
-																	hydrogen.excitation_old(Te_C * Tnorm) * Nnorm /
-																	Omega_ci / Tnorm;
-								R_ex_R = Ne_R * Nn_R *
-																	hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
-																	Omega_ci / Tnorm;
-								
-							
-								Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
-															 (6. * J_C);
-							}
-														 
-							if (atomic_debug) {							 
-								// Calculate the old way for comparison
-								R_ex_L = Ne_L * Nn_L *
-																	hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
-																	Omega_ci / Tnorm;
-								R_ex_C = Ne_C * Nn_C *
-																	hydrogen.excitation_old(Te_C * Tnorm) * Nnorm /
-																	Omega_ci / Tnorm;
-								R_ex_R = Ne_R * Nn_R *
-																	hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
-																	Omega_ci / Tnorm;
-								
-							
-								Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
-															 (6. * J_C);
-							}
+              BoutReal R_ex_L, R_ex_C, R_ex_R;
+
+              if (ex_rate=="solps") {
+                R_ex_L = Ne_L * Nn_L *
+                                  (hydrogen.excitation(Ne_L * Nnorm, Te_L * Tnorm) - hydrogen.ionisation_coronal(Te_L * Tnorm) * 13.6) * Nnorm /
+                                  Omega_ci / Tnorm;
+                R_ex_C = Ne_C * Nn_C *
+                                  (hydrogen.excitation(Ne_C * Nnorm, Te_C * Tnorm) - hydrogen.ionisation_coronal(Te_C * Tnorm) * 13.6) * Nnorm /
+                                  Omega_ci / Tnorm;
+                R_ex_R = Ne_R * Nn_R *
+                                  (hydrogen.excitation(Ne_R * Nnorm, Te_R * Tnorm) - hydrogen.ionisation_coronal(Te_R * Tnorm) * 13.6) * Nnorm /
+                                  Omega_ci / Tnorm;
+
+                Rex(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
+                               (6. * J_C);
+              } else {
+                // Calculate the old way for comparison
+                R_ex_L = Ne_L * Nn_L *
+                                  hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
+                                  Omega_ci / Tnorm;
+                R_ex_C = Ne_C * Nn_C *
+                                  hydrogen.excitation_old(Te_C * Tnorm) * Nnorm /
+                                  Omega_ci / Tnorm;
+                R_ex_R = Ne_R * Nn_R *
+                                  hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
+                                  Omega_ci / Tnorm;
+                
+              
+                Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
+                               (6. * J_C);
+              }
+                             
+              if (atomic_debug) {							 
+                // Calculate the old way for comparison
+                R_ex_L = Ne_L * Nn_L *
+                                  hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
+                                  Omega_ci / Tnorm;
+                R_ex_C = Ne_C * Nn_C *
+                                  hydrogen.excitation_old(Te_C * Tnorm) * Nnorm /
+                                  Omega_ci / Tnorm;
+                R_ex_R = Ne_R * Nn_R *
+                                  hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
+                                  Omega_ci / Tnorm;
+                
+              
+                Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
+                               (6. * J_C);
+              }
             }
 
             // Total energy lost from system

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -141,9 +141,9 @@ protected:
     OPTION(opt, elastic_scattering,
            false);                  // Include ion-neutral elastic scattering?
     OPTION(opt, excitation, false); // Include electron impact excitation?
-	OPTION(opt, dn_model, "default"); // Set to "solkit" to enable SOLKiT neutral diffusion
-	OPTION(opt, cx_model, "default"); // Set to "solkit" to enable SOLKiT charge exchange friction
-	OPTION(opt, atomic_debug, false); // Save Siz_compare and Rex_compare which correspond to SD1D default Siz & Rex 
+		OPTION(opt, dn_model, "default"); // Set to "solkit" to enable SOLKiT neutral diffusion
+		OPTION(opt, cx_model, "default"); // Set to "solkit" to enable SOLKiT charge exchange friction
+		OPTION(opt, atomic_debug, false); // Save Siz_compare and Rex_compare which correspond to SD1D default Siz & Rex 
 
     OPTION(opt, gamma_sound, 5. / 3); // Ratio of specific heats
     bndry_flux_fix =
@@ -593,14 +593,14 @@ protected:
               // Neutral gas diffusion
               if (include_dneut) {
 				  
-				if (dn_model=="solkit") {
-					
-					Dn(i, j, k) = dneut(i, j, k) * sqrt(3 / Tnorm) / (2 * ((8.8e-21*Nnorm*rho_s0) * (Nelim(i, j, k) + Nnlim(i, j, k)) + (3e-19*Nnorm*rho_s0) * Nelim(i, j, k)));
-				} else {
-					Dn(i, j, k) = dneut(i, j, k) * SQ(vth_n) / sigma;
-				}
-                // Neutral gas heat conduction
-                kappa_n(i, j, k) = dneut(i, j, k) * Nnlim(i, j, k) * SQ(vth_n) / sigma;
+								if (dn_model=="solkit") {
+									
+									Dn(i, j, k) = dneut(i, j, k) * sqrt(3 / Tnorm) / (2 * ((8.8e-21*Nnorm*rho_s0) * (Nelim(i, j, k) + Nnlim(i, j, k)) + (3e-19*Nnorm*rho_s0) * Nelim(i, j, k)));
+								} else {
+									Dn(i, j, k) = dneut(i, j, k) * SQ(vth_n) / sigma;
+								}
+												// Neutral gas heat conduction
+												kappa_n(i, j, k) = dneut(i, j, k) * Nnlim(i, j, k) * SQ(vth_n) / sigma;
               }
             }
 
@@ -1004,30 +1004,30 @@ protected:
 			
             if (charge_exchange) {
 				
-				// SOLKIT MODEL (MK 12/05/2022)
-				// CONSTANT CROSS-SECTION 3E-19m2, COLD ION/NEUTRAL AND STATIC NEUTRAL ASSUMPTION
-				if (cx_model == "solkit") {
-					R_cx_L = Ne_L * Nn_L *
-                                3e-19 * Vi_L *
-                                (Nnorm / Omega_ci);
-					R_cx_C = Ne_C * Nn_C *
-                                3e-19 * Vi_C *
-                                (Nnorm / Omega_ci);
-					R_cx_R = Ne_R * Nn_R *
-                                3e-19 * Vi_R *
-                                (Nnorm / Omega_ci);
-				} else {
-				// ORIGINAL MODEL 
-					R_cx_L = Ne_L * Nn_L *
-									hydrogen.chargeExchange(Te_L * Tnorm) *
-									(Nnorm / Omega_ci);
-					R_cx_C = Ne_C * Nn_C *
-									hydrogen.chargeExchange(Te_C * Tnorm) *
-									(Nnorm / Omega_ci);
-					R_cx_R = Ne_R * Nn_R *
-									hydrogen.chargeExchange(Te_R * Tnorm) *
-									(Nnorm / Omega_ci);
-				}
+							// SOLKIT MODEL (MK 12/05/2022)
+							// CONSTANT CROSS-SECTION 3E-19m2, COLD ION/NEUTRAL AND STATIC NEUTRAL ASSUMPTION
+							if (cx_model == "solkit") {
+								R_cx_L = Ne_L * Nn_L *
+																			3e-19 * Vi_L *
+																			(Nnorm / Omega_ci);
+								R_cx_C = Ne_C * Nn_C *
+																			3e-19 * Vi_C *
+																			(Nnorm / Omega_ci);
+								R_cx_R = Ne_R * Nn_R *
+																			3e-19 * Vi_R *
+																			(Nnorm / Omega_ci);
+							} else {
+							// ORIGINAL MODEL 
+								R_cx_L = Ne_L * Nn_L *
+												hydrogen.chargeExchange(Te_L * Tnorm) *
+												(Nnorm / Omega_ci);
+								R_cx_C = Ne_C * Nn_C *
+												hydrogen.chargeExchange(Te_C * Tnorm) *
+												(Nnorm / Omega_ci);
+								R_cx_R = Ne_R * Nn_R *
+												hydrogen.chargeExchange(Te_R * Tnorm) *
+												(Nnorm / Omega_ci);
+							}
 			
               // Ecx is energy transferred to neutrals
               Ecx(i, j, k) = (3. / 2) *
@@ -1111,6 +1111,7 @@ protected:
                   ( // Energy loss per ionisation
                       J_L * R_iz_L + 4. * J_C * R_iz_C + J_R * R_iz_R) /
                   (6. * J_C);
+									
               Eiz(i, j, k) =
                   -(3. / 2) *
                   ( // Energy from neutral atom temperature
@@ -1206,19 +1207,19 @@ protected:
 														 
 							if (atomic_debug) {							 
 								// Calculate the old way for comparison
-							R_ex_L = Ne_L * Nn_L *
-                                (hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
-                                Omega_ci / Tnorm;
-              R_ex_C = Ne_C * Nn_C *
-                                (hydrogen.excitation_old(Te_C * Tnorm) * Nnorm /
-                                Omega_ci / Tnorm;
-              R_ex_R = Ne_R * Nn_R *
-                                (hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
-                                Omega_ci / Tnorm;
+								R_ex_L = Ne_L * Nn_L *
+																	(hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
+																	Omega_ci / Tnorm;
+								R_ex_C = Ne_C * Nn_C *
+																	(hydrogen.excitation_old(Te_C * Tnorm) * Nnorm /
+																	Omega_ci / Tnorm;
+								R_ex_R = Ne_R * Nn_R *
+																	(hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
+																	Omega_ci / Tnorm;
 								
 							
-              Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
-                             (6. * J_C);
+								Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
+															 (6. * J_C);
 							}
             }
 

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1208,13 +1208,13 @@ protected:
 							if (atomic_debug) {							 
 								// Calculate the old way for comparison
 								R_ex_L = Ne_L * Nn_L *
-																	(hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
+																	hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
 																	Omega_ci / Tnorm;
 								R_ex_C = Ne_C * Nn_C *
-																	(hydrogen.excitation_old(Te_C * Tnorm) * Nnorm /
+																	hydrogen.excitation_old(Te_C * Tnorm) * Nnorm /
 																	Omega_ci / Tnorm;
 								R_ex_R = Ne_R * Nn_R *
-																	(hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
+																	hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
 																	Omega_ci / Tnorm;
 								
 							
@@ -1850,7 +1850,7 @@ private:
   // MK additions. See OPTIONS for descriptions
   std::string dn_model;
   std::string cx_model;
-  bool atomic_debug
+  bool atomic_debug;
   
   bool cfl_info; // Print additional information on CFL limits
 

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -557,7 +557,7 @@ protected:
         
         if (cx_model=="solkit") {
           
-          sigma_cx = Nelim(i, j, k) * (3e-19 * Nnorm * rho_s0) * Vi(i, j, k); // Dimensionless 
+          sigma_cx = Nelim(i, j, k) * (3e-19 * Nnorm * rho_s0) * Vi(i, j, k) // Dimensionless 
                     
         } else {
           

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1209,20 +1209,20 @@ protected:
               // Currently assuming that quantity calculated is in [eV m^3/s]
               // MK modified this to calculate net excitation rate from AMJUEL 
               // effective excitation energy rate minus base ionisation energy cost 13.6eV * fION  
-              // where fION is the Sawada ionisation rate in the low density (coronal) limit of 1e-8 m-3
+              // where fION is the Sawada ionisation rate in the low density (coronal) limit of 1e8 cm-3
               // this is used because the coronal limit won't include any excited state effects which are accounted 
-              // for in the excitation energy rate already.
+              // for in the excitation energy rate already. Note functions are in m-3 hence 1e8 * 1e6
               BoutReal R_ex_L, R_ex_C, R_ex_R;
 
               if (ex_rate=="solps") {
                 R_ex_L = Ne_L * Nn_L *
-                                  (hydrogen.excitation(Ne_L * Nnorm, Te_L * Tnorm) - hydrogen.ionisation(1e-8, Te_L * Tnorm) * 13.6) * Nnorm /
+                                  (hydrogen.excitation(Ne_L * Nnorm, Te_L * Tnorm) - hydrogen.ionisation(1e8*1e6, Te_L * Tnorm) * 13.6) * Nnorm /
                                   Omega_ci / Tnorm;
                 R_ex_C = Ne_C * Nn_C *
-                                  (hydrogen.excitation(Ne_C * Nnorm, Te_C * Tnorm) - hydrogen.ionisation(1e-8, Te_C * Tnorm) * 13.6) * Nnorm /
+                                  (hydrogen.excitation(Ne_C * Nnorm, Te_C * Tnorm) - hydrogen.ionisation(1e8*1e6, Te_C * Tnorm) * 13.6) * Nnorm /
                                   Omega_ci / Tnorm;
                 R_ex_R = Ne_R * Nn_R *
-                                  (hydrogen.excitation(Ne_R * Nnorm, Te_R * Tnorm) - hydrogen.ionisation(1e-8, Te_R * Tnorm) * 13.6) * Nnorm /
+                                  (hydrogen.excitation(Ne_R * Nnorm, Te_R * Tnorm) - hydrogen.ionisation(1e8*1e6, Te_R * Tnorm) * 13.6) * Nnorm /
                                   Omega_ci / Tnorm;
 
                 Rex(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -557,7 +557,7 @@ protected:
         
         if (cx_model=="solkit") {
           
-          sigma_cx = Nelim(i, j, k) * (3e-19 * Nnorm * rho_s0) * Vi(i, j, k) // Dimensionless 
+          sigma_cx = Nelim(i, j, k) * (3e-19 * Nnorm * rho_s0) * Vi(i, j, k); // Dimensionless 
                     
         } else {
           

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1151,14 +1151,14 @@ protected:
                 // Rate diagnostics
                 // Calculate field Siz_compare which is saved but doesn't go into other calculations
                 R_iz_L = Ne_L * Nn_L *
-                hydrogen.ionisation(Ne_L * Nnorm, Te_L * Tnorm) * Nnorm /
-                Omega_ci;
+                                hydrogen.ionisation_old(Te_L * Tnorm) * Nnorm /
+                                Omega_ci;
                 R_iz_C = Ne_C * Nn_C *
-                hydrogen.ionisation(Ne_C * Nnorm, Te_C * Tnorm) * Nnorm /
-                Omega_ci;
+                                  hydrogen.ionisation_old(Te_C * Tnorm) * Nnorm /
+                                  Omega_ci;
                 R_iz_R = Ne_R * Nn_R *
-                hydrogen.ionisation(Ne_R * Nnorm, Te_R * Tnorm) * Nnorm /
-                Omega_ci;
+                                  hydrogen.ionisation_old(Te_R * Tnorm) * Nnorm /
+                                  Omega_ci;
 
                 Siz_compare(i, j, k) =
                 -(J_L * R_iz_L + 4. * J_C * R_iz_C + J_R * R_iz_R) /
@@ -1255,6 +1255,9 @@ protected:
                 R_ex_R = Ne_R * Nn_R *
                                   hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
                                   Omega_ci / Tnorm;
+                                  
+                Rex(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
+                               (6. * J_C);
               }
             }
 

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -599,6 +599,8 @@ protected:
           
                 if (dn_model=="solkit") {
                   
+                  BoutReal sigma_ne = 
+                  
                   Dn(i, j, k) = dneut(i, j, k) * sqrt(3 / Tnorm) / (2 * ((8.8e-21*Nnorm*rho_s0) * (Nelim(i, j, k) + Nnlim(i, j, k)) + (3e-19*Nnorm*rho_s0) * Nelim(i, j, k)));
                 } else {
                   Dn(i, j, k) = dneut(i, j, k) * SQ(vth_n) / sigma;
@@ -1012,13 +1014,13 @@ protected:
               // CONSTANT CROSS-SECTION 3E-19m2, COLD ION/NEUTRAL AND STATIC NEUTRAL ASSUMPTION
               if (cx_model == "solkit") {
                 R_cx_L = Ne_L * Nn_L *
-                                      3e-19 * Vi_L *
+                                      3e-19 *Nnorm*rho_s0* Vi_L *
                                       (Nnorm / Omega_ci);
                 R_cx_C = Ne_C * Nn_C *
-                                      3e-19 * Vi_C *
+                                      3e-19 *Nnorm*rho_s0* Vi_C *
                                       (Nnorm / Omega_ci);
                 R_cx_R = Ne_R * Nn_R *
-                                      3e-19 * Vi_R *
+                                      3e-19 *Nnorm*rho_s0* Vi_R *
                                       (Nnorm / Omega_ci);
               } else {
               // ORIGINAL MODEL 

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1209,17 +1209,20 @@ protected:
               // Currently assuming that quantity calculated is in [eV m^3/s]
               // MK modified this to calculate net excitation rate from AMJUEL 
               // effective excitation energy rate minus base ionisation energy cost 13.6eV * fION  
+              // where fION is the Sawada ionisation rate in the low density (coronal) limit of 1e-8 m-3
+              // this is used because the coronal limit won't include any excited state effects which are accounted 
+              // for in the excitation energy rate already.
               BoutReal R_ex_L, R_ex_C, R_ex_R;
 
               if (ex_rate=="solps") {
                 R_ex_L = Ne_L * Nn_L *
-                                  (hydrogen.excitation(Ne_L * Nnorm, Te_L * Tnorm) - hydrogen.ionisation_coronal(Te_L * Tnorm) * 13.6) * Nnorm /
+                                  (hydrogen.excitation(Ne_L * Nnorm, Te_L * Tnorm) - hydrogen.ionisation(1e-8, Te_L * Tnorm) * 13.6) * Nnorm /
                                   Omega_ci / Tnorm;
                 R_ex_C = Ne_C * Nn_C *
-                                  (hydrogen.excitation(Ne_C * Nnorm, Te_C * Tnorm) - hydrogen.ionisation_coronal(Te_C * Tnorm) * 13.6) * Nnorm /
+                                  (hydrogen.excitation(Ne_C * Nnorm, Te_C * Tnorm) - hydrogen.ionisation(1e-8, Te_C * Tnorm) * 13.6) * Nnorm /
                                   Omega_ci / Tnorm;
                 R_ex_R = Ne_R * Nn_R *
-                                  (hydrogen.excitation(Ne_R * Nnorm, Te_R * Tnorm) - hydrogen.ionisation_coronal(Te_R * Tnorm) * 13.6) * Nnorm /
+                                  (hydrogen.excitation(Ne_R * Nnorm, Te_R * Tnorm) - hydrogen.ionisation(1e-8, Te_R * Tnorm) * 13.6) * Nnorm /
                                   Omega_ci / Tnorm;
 
                 Rex(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1244,10 +1244,8 @@ protected:
                   Rex_compare(i, j, k) = (J_L * R_ex_L + 4. * J_C * R_ex_C + J_R * R_ex_R) /
                                  (6. * J_C);
                 }
-              }
-              
               } else {
-                // Calculate the old way for comparison
+                // Calculate the SD1D default way
                 R_ex_L = Ne_L * Nn_L *
                                   hydrogen.excitation_old(Te_L * Tnorm) * Nnorm /
                                   Omega_ci / Tnorm;
@@ -1257,10 +1255,7 @@ protected:
                 R_ex_R = Ne_R * Nn_R *
                                   hydrogen.excitation_old(Te_R * Tnorm) * Nnorm /
                                   Omega_ci / Tnorm;
-           
               }
-                             
-              
             }
 
             // Total energy lost from system

--- a/sd1d.cxx
+++ b/sd1d.cxx
@@ -1011,12 +1011,15 @@ protected:
         
               // SOLKIT MODEL (MK 12/05/2022)
               // CONSTANT CROSS-SECTION 3E-19m2, COLD ION/NEUTRAL AND STATIC NEUTRAL ASSUMPTION
+              
+              // Multiplied by Omega_Ci only because it's what it takes to get the results right......
+              // As far as I know this is not correct.
               if (cx_model == "solkit") {
-                R_cx_L = Ne_L * Nn_L * (3e-19 * Nnorm * rho_s0) * Vi_L;
+                R_cx_L = Ne_L * Nn_L * (3e-19 * Nnorm * rho_s0) * Vi_L * Omega_ci;
 
-                R_cx_C = Ne_C * Nn_C * (3e-19 * Nnorm * rho_s0) * Vi_C;
+                R_cx_C = Ne_C * Nn_C * (3e-19 * Nnorm * rho_s0) * Vi_C * Omega_ci;
 
-                R_cx_R = Ne_R * Nn_R * (3e-19 * Nnorm * rho_s0) * Vi_R;
+                R_cx_R = Ne_R * Nn_R * (3e-19 * Nnorm * rho_s0) * Vi_R * Omega_ci;
 
               } else {
               // ORIGINAL MODEL 


### PR DESCRIPTION
This merge pushes the following changes:
- Switches for IZ, EX, Dn, CX rates, which can be "default" or "solkit".
- Fixed implementation of the above which had some normalisation issues.
- One key issue was the net excitation rate which used the coronal ionisation rate which was plain wrong. This was responsible for negative net excitation, which is now resolved.
- As far as I know everything is correct as of this merge.